### PR TITLE
SECURITY.md: Add clarification to not disclose publicly

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,29 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+DigitalOcean values the security of our open source projects. We appreciate the efforts of security researchers and the broader community in helping us maintain a high level of security.
+
+**Bug Bounty Program**
+
+We operate a public bug bounty program on [Intigriti](https://app.intigriti.com/programs/digitalocean/digitalocean/detail). This program is designed to incentivize the responsible disclosure of security vulnerabilities.
+
+**In-Scope Repositories**
+
+Only repositories listed on the [Intigriti program page](https://app.intigriti.com/programs/digitalocean/digitalocean/detail) are eligible for rewards under the bug bounty program.
+
+**Out-of-Scope Repositories**
+
+If you discover a vulnerability in a repository not listed on the Intigriti page, we still encourage you to report it. While such findings are not eligible for monetary rewards, we value your contribution to the security of our open-source projects. 
+
+Please send any ineligible findings to [security@digitalocean.com](mailto:security@digitalocean.com).
+
+**Guidelines**
+
+* **Responsible Disclosure:** Please do not publicly disclose the vulnerability without written permission from DigitalOcean.
+* **Clear Description:** Provide a detailed description of the vulnerability, including steps to reproduce it and any relevant proof-of-concept code.
+* **Impact Assessment:** Help us understand the potential impact of the vulnerability.
+
+We are committed to working with you to resolve security issues in a timely and responsible manner.
+
+Thank you for your help in keeping DigitalOcean and our community secure!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ Only repositories listed on the [Intigriti program page](https://app.intigriti.c
 
 If you discover a vulnerability in a repository not listed on the Intigriti page, we still encourage you to report it. While such findings are not eligible for monetary rewards, we value your contribution to the security of our open-source projects.
 
-Please send any ineligible findings to [security@digitalocean.com](mailto:security@digitalocean.com). If you wish to encrypt your communication, follow [these instructions](https://github.com/digitalocean/security).
+**Please do not open public issues describing vulnerabilities.** Instead, send any ineligible findings to [security@digitalocean.com](mailto:security@digitalocean.com). If you wish to encrypt your communication, follow [these instructions](https://github.com/digitalocean/security).
 
 **Guidelines**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,6 @@
-# Security Policy
-
 ## Reporting a Vulnerability
 
-DigitalOcean values the security of our open source projects. We appreciate the efforts of security researchers and the broader community in helping us maintain a high level of security.
+DigitalOcean values the security of our open source projects. We appreciate the efforts of security researchers and the broader community to help keep our customers and business safe.
 
 **Bug Bounty Program**
 
@@ -12,11 +10,9 @@ We operate a public bug bounty program on [Intigriti](https://app.intigriti.com/
 
 Only repositories listed on the [Intigriti program page](https://app.intigriti.com/programs/digitalocean/digitalocean/detail) are eligible for rewards under the bug bounty program.
 
-**Out-of-Scope Repositories**
+If you discover a vulnerability in a repository not listed on the Intigriti page, we still encourage you to report it. While such findings are not eligible for monetary rewards, we value your contribution to the security of our open-source projects.
 
-If you discover a vulnerability in a repository not listed on the Intigriti page, we still encourage you to report it. While such findings are not eligible for monetary rewards, we value your contribution to the security of our open-source projects. 
-
-Please send any ineligible findings to [security@digitalocean.com](mailto:security@digitalocean.com).
+Please send any ineligible findings to [security@digitalocean.com](mailto:security@digitalocean.com). If you wish to encrypt your communication, follow [these instructions](https://github.com/digitalocean/security).
 
 **Guidelines**
 


### PR DESCRIPTION
Add clarification to make sure that vulnerabilities are not made public before they are addressed. 